### PR TITLE
Fix build error

### DIFF
--- a/camera/cameraserver/Android.bp
+++ b/camera/cameraserver/Android.bp
@@ -21,7 +21,7 @@ cc_binary {
     srcs: ["main_cameraserver.cpp"],
 
     shared_libs: [
-        "libcameraservice",
+        "//frameworks/av/services/camera/libcameraservice:libcameraservice",
         "liblog",
         "libutils",
         "libui",

--- a/camera/cameraserver/Android.bp
+++ b/camera/cameraserver/Android.bp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+soong_namespace {
+}
+
 cc_binary {
     name: "cameraserver",
 

--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+soong_namespace {
+}
+
 //
 // libcameraservice
 //


### PR DESCRIPTION
These commits to fix the below build error
frameworks/av/camera/cameraserver/main_cameraserver.cpp:20:10: fatal error: 'CameraService.h' file not found                                                                      #include "CameraService.h"                                                                        
^~~~~~~~~~~~~~~~~                                                               
1 error generated.

Thanks to @srgrusso