### PR TITLE
mediaplayer: Add default constructor for media player

### DIFF
--- a/media/libmedia/include/media/mediaplayer.h
+++ b/media/libmedia/include/media/mediaplayer.h
@@ -207,7 +207,8 @@ class MediaPlayer : public BnMediaPlayerClient,
                     public virtual IMediaDeathNotifier
 {
 public:
-    MediaPlayer(const std::string opPackageName = "");
+    MediaPlayer();
+    explicit MediaPlayer(const std::string opPackageName);
     ~MediaPlayer();
             void            died();
             void            disconnect();

--- a/media/libmedia/mediaplayer.cpp
+++ b/media/libmedia/mediaplayer.cpp
@@ -41,10 +41,7 @@ namespace android {
 
 using media::VolumeShaper;
 
-MediaPlayer::MediaPlayer()
-{
-    MediaPlayer("");
-}
+MediaPlayer::MediaPlayer() : MediaPlayer("") {}
 
 MediaPlayer::MediaPlayer(const std::string opPackageName) : mOpPackageName(opPackageName)
 {

--- a/media/libmedia/mediaplayer.cpp
+++ b/media/libmedia/mediaplayer.cpp
@@ -41,6 +41,11 @@ namespace android {
 
 using media::VolumeShaper;
 
+MediaPlayer::MediaPlayer()
+{
+    MediaPlayer("");
+}
+
 MediaPlayer::MediaPlayer(const std::string opPackageName) : mOpPackageName(opPackageName)
 {
     ALOGV("constructor");


### PR DESCRIPTION
These commits allow to use a prebuild camera provider  for some devices